### PR TITLE
[Fix] Fix 'already connected' warning after server shutdown

### DIFF
--- a/src/main/java/com/chinese_checkers/game/Game.java
+++ b/src/main/java/com/chinese_checkers/game/Game.java
@@ -87,7 +87,7 @@ public class Game
 			return;
 		}
 
-		if (server != null)
+		if (server != null && server.isConnected())
 		{
 			System.out.println("Already connected to a server. Type 'disconnect' to disconnect.");
 			return;

--- a/src/main/java/com/chinese_checkers/networking/NetworkConnector.java
+++ b/src/main/java/com/chinese_checkers/networking/NetworkConnector.java
@@ -155,4 +155,9 @@ public class NetworkConnector
 			return null;
 		}
 	}
+
+	public boolean isConnected()
+	{
+		return socket != null && listener.isRunning();
+	}
 }

--- a/src/main/java/com/chinese_checkers/networking/NetworkListener.java
+++ b/src/main/java/com/chinese_checkers/networking/NetworkListener.java
@@ -11,7 +11,7 @@ public class NetworkListener extends Thread
 	private final BufferedReader in;
 	private final ReentrantLock threadLock;
 	private final CommandParser commandParser;
-	private boolean running = true;
+	private boolean running = false;
 
 
 	public NetworkListener(final BufferedReader in, final ReentrantLock threadLock, final CommandParser commandParser)
@@ -25,6 +25,7 @@ public class NetworkListener extends Thread
 	@Override
 	public void run()
 	{
+		running = true;
 		String line;
 
 		try
@@ -62,6 +63,7 @@ public class NetworkListener extends Thread
 		{
 			if (threadLock.isHeldByCurrentThread())
 				threadLock.unlock();
+			running = false;
 		}
 
 		System.out.println("Connection closed");
@@ -70,5 +72,10 @@ public class NetworkListener extends Thread
 	public void terminate()
 	{
 		running = false;
+	}
+
+	public boolean isRunning()
+	{
+		return running;
 	}
 }


### PR DESCRIPTION
When server is shut down, connected client displays message "Connection closed", however the connection isn't really closing, because the next connection attempt after server restart was resulting in "Already connected" warning. I've fixed this by changing 'running' flag behavior in NetworkListener, and adding getter functions to determine if the connection is open or closed.